### PR TITLE
Custom SR labels to Pill

### DIFF
--- a/eik.json
+++ b/eik.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabric-ds/react",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "server": "https://assets.finn.no",
   "type": "package",
   "files": "./dist/eik",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabric-ds/react",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "repository": "git@github.com:fabric-ds/react.git",
   "license": "ISC",
   "type": "module",

--- a/packages/pill/docs/Pill.mdx
+++ b/packages/pill/docs/Pill.mdx
@@ -3,7 +3,8 @@ import { IconSearch16, IconPlus16 } from '@fabric-ds/icons/react';
 
 # Pill
 
-Pill is a type of button that can also be used as filters.
+Pill is a type of button that is often used as a filter, but can also be used as
+a rounded button for overlays, etc.
 
 ## Import
 

--- a/packages/pill/src/component.tsx
+++ b/packages/pill/src/component.tsx
@@ -28,7 +28,7 @@ export function Pill(props: PillProps) {
           [props.canClose ? c.labelWithClose : c.labelWithoutClose]: true,
         })}
       >
-        <span className="sr-only">Åpne filter </span>
+        <span className="sr-only">{props.openSRLabel || 'Åpne filter'}</span>
         {props.icon || <span>{props.label}</span>}
       </button>
       {props.canClose && (
@@ -41,7 +41,9 @@ export function Pill(props: PillProps) {
           })}
           onClick={props.onClose}
         >
-          <span className="sr-only">Fjern filter {props.label}</span>
+          <span className="sr-only">
+            {props.closeSRLabel || `Fjern filter ${props.label}`}
+          </span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="12"

--- a/packages/pill/src/props.tsx
+++ b/packages/pill/src/props.tsx
@@ -5,6 +5,16 @@ export type PillProps = {
   label?: string;
 
   /**
+   * Label read by screen readers when targetting a pill
+   */
+  openSRLabel?: string;
+
+  /**
+   * Label read by screen readers when targetting the pill close button
+   */
+  closeSRLabel?: string;
+
+  /**
    * Render icon inside of Pill
    */
   icon?: React.ReactNode;


### PR DESCRIPTION
Allow the user to set custom labels for the open/click and close button in the Pill component.