### PR TITLE
chore: simplify publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,5 @@ yarn docs:dev
 
 ## How to release
 
-1. `npm run build` - Builds files in ./dist directory
-1. `npm run publish` - Releases to npm
-1. `npm run eik:publish` - publishes to the Eik server
-1. `npm run eik:alias` - Update the Eik alias
+Run `npm version major|minor|patch`. 
+Pre and post hooks will take care of Eik login, asset building and publishing to NPM and Eik.

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "eik:publish": "npx @eik/cli publish",
     "eik:alias": "npx @eik/cli pkg-alias",
     "preversion": "npx @eik/cli login && npm run build",
-    "version": "npm publish",
-    "postversion": "npm run eik:publish && git push --follow-tags"
+    "postversion": "npm publish && npm run eik:publish && git push --follow-tags"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "lint:eslint": "eslint . --ext ts,tsx,js,jsx,cjs --max-warnings 0 --ignore-path .gitignore",
     "lint:format": "prettier --check . --ignore-path .gitignore",
     "eik:publish": "npx @eik/cli publish",
-    "eik:alias": "npx @eik/cli pkg-alias"
+    "eik:alias": "npx @eik/cli pkg-alias",
+    "preversion": "npx @eik/cli login && npm run build",
+    "version": "npm publish",
+    "postversion": "npm run eik:publish && git push --follow-tags"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
This should ™️ make it so you can just run `npm version major|minor|patch` to do all versioning and publishing in a single hit.