### PR TITLE
Fix React dev errors

### DIFF
--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -2,61 +2,70 @@ import React, { forwardRef, Ref } from 'react';
 import { classNames } from '@chbphone55/classnames';
 import type { ButtonProps } from './props';
 
-export const Button = forwardRef(
-  (
-    props: ButtonProps,
-    ref: Ref<HTMLButtonElement> | Ref<HTMLAnchorElement>,
-  ) => {
-    const classes = classNames(props.className, {
-      button: true,
-      // primary buttons
-      'button--primary': props.primary,
-      'button--destructive': props.negative,
-      // quiet
-      'button--flat': props.secondary && props.quiet,
-      'button--destructive-flat': props.negative && props.quiet,
-      'button--utility-flat': props.utility && props.quiet,
-      // others
-      'button--small': props.small,
-      'button--utility': props.utility && !props.quiet,
-      'button--link': props.link,
-      'button--pill': props.pill,
-      'button--in-progress': props.loading,
-    });
+export const Button = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  ButtonProps
+>((props, ref) => {
+  const {
+    primary,
+    secondary,
+    negative,
+    utility,
+    quiet,
+    small,
+    link,
+    pill,
+    loading,
+    ...rest
+  } = props;
 
-    return (
-      <>
-        {props.href ? (
-          <a
-            href={props.href}
-            target={props.target}
-            rel={
-              props.target === '_blank' ? props.rel || 'noopener' : undefined
-            }
-            ref={ref as Ref<HTMLAnchorElement>}
-            className={classes}
-          >
-            {props.children}
-          </a>
-        ) : (
-          <button
-            {...props}
-            type={props.type || 'button'}
-            ref={ref as Ref<HTMLButtonElement>}
-            className={classes}
-          >
-            {props.children}
-          </button>
-        )}
-        {props.loading ? (
-          <span
-            className="sr-only"
-            role="progressbar"
-            aria-valuenow={0}
-            aria-valuetext="Laster..."
-          />
-        ) : null}
-      </>
-    );
-  },
-);
+  const classes = classNames(props.className, {
+    button: true,
+    // primary buttons
+    'button--primary': primary,
+    'button--destructive': negative,
+    // quiet
+    'button--flat': secondary && quiet,
+    'button--destructive-flat': negative && quiet,
+    'button--utility-flat': utility && quiet,
+    // others
+    'button--small': small,
+    'button--utility': utility && !quiet,
+    'button--link': link,
+    'button--pill': pill,
+    'button--in-progress': loading,
+  });
+
+  return (
+    <>
+      {props.href ? (
+        <a
+          href={props.href}
+          target={props.target}
+          rel={props.target === '_blank' ? props.rel || 'noopener' : undefined}
+          ref={ref as Ref<HTMLAnchorElement>}
+          className={classes}
+        >
+          {props.children}
+        </a>
+      ) : (
+        <button
+          {...rest}
+          type={props.type || 'button'}
+          ref={ref as Ref<HTMLButtonElement>}
+          className={classes}
+        >
+          {props.children}
+        </button>
+      )}
+      {props.loading ? (
+        <span
+          className="sr-only"
+          role="progressbar"
+          aria-valuenow={0}
+          aria-valuetext="Laster..."
+        />
+      ) : null}
+    </>
+  );
+});

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -28,6 +28,7 @@ export const Button = forwardRef(
       <>
         {props.href ? (
           <a
+            href={props.href}
             target={props.target}
             rel={
               props.target === '_blank' ? props.rel || 'noopener' : undefined

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -153,8 +153,8 @@ export const Example = () => {
         <h3>Link (href)</h3>
         {/* @ts-ignore */}
         <Button
-          className="mr-32"
           link
+          className="mr-32"
           href="https://google.com/"
           target="_blank"
         >

--- a/packages/card/src/component.tsx
+++ b/packages/card/src/component.tsx
@@ -3,11 +3,12 @@ import { card as c } from '@fabric-ds/component-classes';
 import { classNames } from '@chbphone55/classnames';
 import { CardProps } from './props';
 
-export function Card({ as = 'article', children, ...props }: CardProps) {
+export function Card(props: CardProps) {
+  const { as = 'article', children, flat, ...rest } = props;
   return React.createElement(
     as,
     {
-      ...props,
+      ...rest,
       className: classNames(props.className, {
         [c.card]: true,
         [c.cardShadow]: !props.flat,

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -39,8 +39,8 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         : options;
 
     const handleSelect = (option: Option) => {
-      props.onSelect && props.onSelect(option.value);
       props.onChange(option.value);
+      props.onSelect && props.onSelect(option.value);
 
       setActive(null);
       setMenuOpen(false);

--- a/packages/tabs/src/component-tab-panel.tsx
+++ b/packages/tabs/src/component-tab-panel.tsx
@@ -3,12 +3,12 @@ import { tab as c } from '@fabric-ds/component-classes';
 import type { TabPanelProps } from './props';
 
 export function TabPanel(props: TabPanelProps) {
-  const { children, name, hidden, ...attrs } = props;
+  const { children, name, hidden, ...rest } = props;
 
   return (
     <div
       tabIndex={-1}
-      {...attrs}
+      {...rest}
       role="tabpanel"
       aria-labelledby={`fabric-tab-${name}`}
       id={`fabric-tabpanel-${name}`}

--- a/packages/tabs/src/component-tab.tsx
+++ b/packages/tabs/src/component-tab.tsx
@@ -38,10 +38,10 @@ export function Tab(props: TabProps) {
     setActive = () => {},
     name,
     onClick,
-    over,
     isActive,
   } = props;
   const { tab, icon, content, attrs } = setup(props);
+  const { over, ...rest } = attrs;
 
   const handleClick = (e) => {
     setActive(name);
@@ -51,7 +51,7 @@ export function Tab(props: TabProps) {
   return (
     <button
       type="button"
-      {...attrs}
+      {...rest}
       role="tab"
       aria-selected={isActive ? 'true' : 'false'}
       aria-controls={isActive ? `fabric-tabpanel-${name}` : undefined}


### PR DESCRIPTION
React will complain when we spread props that are non-native, such as custom boolean attributes that are only meant for the component to handle different visual styles, elements rendered, etc. This PR ensures that we only spread native or semantically correct props.