### PR TITLE
fix(combobox): swap onChange and onSelect order

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -39,8 +39,8 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         : options;
 
     const handleSelect = (option: Option) => {
-      props.onSelect && props.onSelect(option.value);
       props.onChange(option.value);
+      props.onSelect && props.onSelect(option.value);
 
       setActive(null);
       setMenuOpen(false);


### PR DESCRIPTION
Swaps the order of `onChange` and `onSelect` in the `handleSelect` in order to improve the control over the event listener