### PR TITLE
feat(combobox): improve control over input field and options

### DIFF
--- a/packages/combobox/docs/Combobox.mdx
+++ b/packages/combobox/docs/Combobox.mdx
@@ -29,6 +29,7 @@ function Example() {
       label="Choose a fruit"
       value={value}
       onChange={(val) => setValue(val)}
+      onSelect={(val) => setValue(val)}
       options={[
         { value: 'Apple' },
         { value: 'Banana' },
@@ -58,6 +59,7 @@ function Example() {
       label="Choose a fruit"
       value={value}
       onChange={(val) => setValue(val)}
+      onSelect={(val) => setValue(val)}
       matchTextSegments
       options={[
         { value: 'Apple' },
@@ -96,6 +98,7 @@ function Example() {
       placeholder="Custom Option Rendering"
       value={value}
       onChange={(val) => setValue(val)}
+      onSelect={(val) => setValue(val)}
       matchTextSegments
       options={[
         { value: 'Apple', label: '🍎 Apple' },
@@ -134,7 +137,10 @@ function Example() {
       matchTextSegments
       value={value}
       onChange={(val) => setValue(val)}
-      onSelect={(val) => alert(val)}
+      onSelect={(val) => {
+        setValue(val);
+        alert(val);
+      }}
       options={characters}
     />
   );
@@ -185,6 +191,7 @@ function Example() {
       placeholder="Your favorite fruit"
       value={value}
       onChange={(val) => setValue(val)}
+      onSelect={(val) => setValue(val)}
       matchTextSegments
       options={[
         { value: 'Apple', label: '🍎 Apple' },

--- a/packages/combobox/docs/Combobox.mdx
+++ b/packages/combobox/docs/Combobox.mdx
@@ -206,6 +206,35 @@ function Example() {
 }
 ```
 
+### Clearing input on select
+
+If you want, you can have the input field cleared after a value has been
+selected
+
+```jsx example
+function Example() {
+  const [value, setValue] = useState('');
+
+  return (
+    <Combobox
+      label="Choose a fruit"
+      value={value}
+      onChange={(val) => setValue(val)}
+      onSelect={(val) => {
+        alert(val);
+        setValue('');
+      }}
+      options={[
+        { value: 'Apple' },
+        { value: 'Banana' },
+        { value: 'Orange' },
+        { value: 'Pineapple' },
+      ]}
+    />
+  );
+}
+```
+
 ## Combobox Props
 
 ```props packages/combobox/src/component.tsx

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -155,8 +155,6 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     }, [props.value]);
 
     useEffect(() => {
-      if (!props.options.length) return;
-
       setOptions(
         props.options.map((o: ComboboxOption) => ({
           ...o,

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -39,7 +39,6 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         : options;
 
     const handleSelect = (option: Option) => {
-      props.onChange(option.value);
       props.onSelect && props.onSelect(option.value);
 
       setActive(null);

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -150,9 +150,14 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     });
 
     useEffect(() => {
-      if (!props.value.trim().length) setMenuOpen(false);
-      if (props.value.length) setMenuOpen(true);
-    }, [props.value]);
+      // only open the menu if input field has value and options exist
+      // this will prevent showing a mini menu without content if no options are present
+      if (props.value.trim().length && options.length) {
+        setMenuOpen(true);
+      } else {
+        setMenuOpen(false);
+      }
+    }, [options.length, props.value]);
 
     useEffect(() => {
       setOptions(

--- a/packages/combobox/stories/Combobox.stories.tsx
+++ b/packages/combobox/stories/Combobox.stories.tsx
@@ -16,7 +16,10 @@ export const Basic = () => {
         label="Stillingstittel"
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         options={[
           { value: 'Product manager' },
           { value: 'Produktledelse' },
@@ -37,7 +40,10 @@ export const MatchTextSegments = () => {
       <Combobox
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         matchTextSegments
         label="Stillingstittel"
         options={[
@@ -60,7 +66,10 @@ export const OpenOnFocus = () => {
       <Combobox
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         openOnFocus
         label="Stillingstittel"
         options={[
@@ -86,7 +95,10 @@ export const SelectOnClick = () => {
       <Combobox
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         label="Stillingstittel"
         options={[
           { value: 'Product manager' },
@@ -107,7 +119,10 @@ export const OptionText = () => {
       <Combobox
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         label="Favorite fruit"
         placeholder="What's your favorite fruit?"
         options={[
@@ -129,7 +144,10 @@ export const WithAffix = () => {
       <Combobox
         value={value}
         onChange={(val) => setValue(val)}
-        onSelect={action('select')}
+        onSelect={(val) => {
+          setValue(val);
+          action('select')(val);
+        }}
         label="Favorite fruit"
         placeholder="What's your favorite fruit?"
         options={[


### PR DESCRIPTION
This PR improves the control over the combobox component by: 
- removing the `props.onChange` call from the `handleSelect` fn, giving the users the option to set a value manually in the `onSelect` prop fn
- clearing the `options` state if `props.options` gets cleared

I also made it so that the menu won't open unless the input field has a value _and_ there are options available. This will prevent an empty menu showing up (e.g ⬇️ )

![bilde](https://user-images.githubusercontent.com/8539877/144064023-5cdf4b3a-55a8-4ac6-a87c-3a2278c2e94e.png)

**EDIT:**
It's worth noting that the removal of `props.onChange` might "break" the expected functionality for some users, so it might be a good idea to write a quick post in slack before publishing 😛 