### PR TITLE
fix(combobox): hide empty menu using css instead of not rendering it

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -150,14 +150,9 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     });
 
     useEffect(() => {
-      // only open the menu if input field has value and options exist
-      // this will prevent showing a mini menu without content if no options are present
-      if (props.value.trim().length && options.length) {
-        setMenuOpen(true);
-      } else {
-        setMenuOpen(false);
-      }
-    }, [options.length, props.value]);
+      if (!props.value.trim().length) setMenuOpen(false);
+      if (props.value.length) setMenuOpen(true);
+    }, [props.value]);
 
     useEffect(() => {
       setOptions(
@@ -219,6 +214,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
             ref={listRef}
             className={classNames(props.listClassName, {
               'absolute left-0 right-0 pb-8 rounded-8 bg-white shadow': true,
+              'sr-only': !options.length,
             })}
             style={{
               zIndex: 2,


### PR DESCRIPTION
Noticed a bug introduced in #62 where the `Ingen treff, viser ...` sr-only span was missing, as the menu/container wouldn't render at all if no options were present. 

This PR fixes that issue by reverting the code that prevented the menu from rendering, and hiding the menu visually instead (if there are no options) 