### PR TITLE
chore!: use React v17 for Eik build

### DIFF
--- a/eik.json
+++ b/eik.json
@@ -5,7 +5,6 @@
   "type": "package",
   "files": "./dist/eik",
   "import-map": [
-    "https://assets.finn.no/map/finn/v2",
-    "https://assets.finn.no/map/troika-css/v1"
+    "https://assets.finn.no/map/react/v2"
   ]
 }


### PR DESCRIPTION
Pretty straight forward change to use the import map for React v17. Removes the old Troika map as well.

What this actually means:
* When people use this version of the library in production, components will be referring to our version of React v17 on the Eik server. 

**Example:**

In their own code:
```js
import { Button } from '@fabric-ds/react';
```

Then they run a build using esbuild or rollup with the Eik plugin and that code will be transformed to:
```js
import { Button } from 'https://assets.finn.no/pkg/@fabric-ds/react/v1/index.js';
```

and then `https://assets.finn.no/pkg/@fabric-ds/react/v1/index.js` in turn has already had all its internal references to React mapped to `https://assets.finn.no/npm/react/v17/react.production.min.js`

Once we merge this PR we will need to:
* Update the Fabric React lib to 1.0.0
* Publish to NPM and Eik
* Create a v1 alias on Eik that points to 1.0.0 for the Fabric React lib
* Update the import map https://assets.finn.no/map/react/2.0.0 to https://assets.finn.no/map/react/2.0.1 and change react from v0 -> v1 for its Fabric React ref.