### PR TITLE
fix: upgrade esbuild plugin to support eik config defined in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@chbphone55/classnames": "^2.0.0",
-    "@eik/esbuild-plugin": "^1.0.4",
+    "@eik/esbuild-plugin": "^1.1.0",
     "@fabric-ds/component-classes": "^0.0.35",
     "@fabric-ds/icons": "^0.3.12",
     "@fabric-ds/tailwind-config": "^0.5.20",


### PR DESCRIPTION
There was a problem with the esbuild plugin that meant that import maps were not being read (and therefore react was being inlined). This fixes that by updating to the latest version of the esbuild plugin.

You can read more about the change to the esbuild plugin here: https://github.com/eik-lib/esbuild-plugin/pull/36