### PR TITLE
Hides expandable body for screen readers when closed

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -100,6 +100,7 @@ export function Expandable(props: ExpandableProps) {
           'overflow-hidden': true,
           'h-0': !stateExpanded,
         })}
+        aria-hidden={!stateExpanded}
       >
         <div className={contentClasses}>{children}</div>
       </div>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -98,7 +98,7 @@ export function Expandable(props: ExpandableProps) {
         ref={boxRef}
         className={classNames({
           'overflow-hidden': true,
-          'h-0': !stateExpanded,
+          'h-0 invisible': !stateExpanded,
         })}
         aria-hidden={!stateExpanded}
       >


### PR DESCRIPTION
### Problem
For screen reader users the body of the expandable is available at all times, making the "open"/"close" button confusing when no new content shows up when the button switches to aria-expanded="true". 

### Solution
Aria-hidden will now hide the content for screen readers and make the experience similar to visual users.