### PR TITLE
fix: add missing id to combobox option

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -284,6 +284,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
                 return (
                   <li
                     key={option.id}
+                    id={option.id}
                     aria-selected={active?.id === option.id || false}
                     role="option"
                     tabIndex={-1}


### PR DESCRIPTION
This PR adds an `id` attribute to the combobox option elements. The option ID is referenced by the `aria-activedescendant` attribute on the combobox input, as described here https://www.w3.org/TR/wai-aria-practices-1.2/#listbox-popup-keyboard-interaction

The unit tests in this repo do not seem to be in a runnable state, so I didn't add any tests for this change.

Before, with missing `id`:
![Skjermbilde 2021-12-22 kl  15 50 06](https://user-images.githubusercontent.com/6734787/147112180-4baadfb3-ce2e-447c-a16d-2d1b42a90997.png)

After:
![Skjermbilde 2021-12-22 kl  15 49 30](https://user-images.githubusercontent.com/6734787/147112213-c256502a-451c-40ce-8d88-04277e84567c.png)
