### PR TITLE
fix: Enter key event

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -40,9 +40,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
 
     const handleSelect = (option: Option) => {
       props.onSelect && props.onSelect(option.value);
-
       setActive(null);
-      setMenuOpen(false);
     };
 
     const handlekeyDown = (e) => {
@@ -107,9 +105,13 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           setActive(null);
           break;
         case 'Enter':
-          e.preventDefault();
-          if (!active) return;
-          handleSelect(active);
+          if (active) {
+            // Handle Enter only when option is selected, otherwise let the event
+            // bubble up to any enclosing form elements etc.
+            e.preventDefault();
+            handleSelect(active);
+          }
+          setMenuOpen(false);
           break;
         case 'Backspace':
           props.onChange(active?.value || props.value);
@@ -291,6 +293,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
                       setActive(option);
                       setTimeout(() => {
                         handleSelect(option);
+                        setMenuOpen(false);
                       }, 1);
                     }}
                     className={classNames({

--- a/packages/combobox/stories/Combobox.stories.tsx
+++ b/packages/combobox/stories/Combobox.stories.tsx
@@ -31,6 +31,42 @@ export const Basic = () => {
   );
 };
 
+export const BubbleEventOnEnter = () => {
+  const [value, setValue] = React.useState('');
+
+  React.useEffect(() => {
+    console.log('Bubbled value', value);
+  }, [value]);
+
+  return (
+    <>
+      <p>Start typing to see suggestions</p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          alert(value);
+        }}
+      >
+        <Combobox
+          label="Stillingstittel"
+          value={value}
+          onChange={(val) => setValue(val)}
+          onSelect={(val) => {
+            setValue(val);
+            action('select')(val);
+          }}
+          options={[
+            { value: 'Product manager' },
+            { value: 'Produktledelse' },
+            { value: 'Prosessoperatør' },
+            { value: 'Prosjekteier' },
+          ]}
+        />
+      </form>
+    </>
+  );
+};
+
 export const MatchTextSegments = () => {
   const [value, setValue] = React.useState('');
 


### PR DESCRIPTION
This PR allows the `Enter` key event to bubble up to an enclosing form. This is useful for use cases where the combobox input is used for free-text search.