### PR TITLE
fix: use inital type for input autocomplete prop

### DIFF
--- a/packages/combobox/src/props.ts
+++ b/packages/combobox/src/props.ts
@@ -79,4 +79,7 @@ export type ComboboxProps = {
 
   /** For affix use */
   children?: JSX.Element;
-};
+} & Omit<
+  React.PropsWithoutRef<JSX.IntrinsicElements['input']>,
+  'onBlur' | 'onFocus' | 'onChange' | 'type' | 'value' | 'label'
+>;

--- a/packages/combobox/stories/Combobox.stories.tsx
+++ b/packages/combobox/stories/Combobox.stories.tsx
@@ -108,6 +108,7 @@ export const OpenOnFocus = () => {
         }}
         openOnFocus
         label="Stillingstittel"
+        autoComplete="password"
         options={[
           { value: 'Product manager' },
           { value: 'Produktledelse' },

--- a/packages/combobox/stories/Combobox.stories.tsx
+++ b/packages/combobox/stories/Combobox.stories.tsx
@@ -108,7 +108,6 @@ export const OpenOnFocus = () => {
         }}
         openOnFocus
         label="Stillingstittel"
-        autoComplete="password"
         options={[
           { value: 'Product manager' },
           { value: 'Produktledelse' },

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -1,11 +1,11 @@
 import { classNames } from '@chbphone55/classnames';
-import { useId } from '../../utils/src';
 import React, { forwardRef } from 'react';
+import { useId } from '../../utils/src';
 import { TextFieldProps } from './props';
 
-export const TextField = forwardRef(
-  (
-    {
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  (props, ref) => {
+    const {
       className,
       disabled,
       id: providedId,
@@ -17,10 +17,9 @@ export const TextField = forwardRef(
       readOnly,
       type = 'text',
       style,
-      ...props
-    }: TextFieldProps,
-    ref: React.Ref<HTMLInputElement>,
-  ) => {
+      ...rest
+    } = props;
+
     const id = useId(providedId);
 
     const helpId = helpText ? `${id}__hint` : undefined;
@@ -45,7 +44,7 @@ export const TextField = forwardRef(
             style={style}
           >
             <input
-              {...props}
+              {...rest}
               aria-describedby={helpId}
               aria-errormessage={isInvalid && helpId ? helpId : undefined}
               aria-invalid={isInvalid}

--- a/packages/textfield/src/props.ts
+++ b/packages/textfield/src/props.ts
@@ -1,7 +1,4 @@
 export type TextFieldProps = {
-  /** Describes the type of autocomplete functionality the input should provide if any. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautocomplete) .*/
-  autoComplete?: boolean;
-
   /** Whether the element should receive focus on render. */
   autoFocus?: boolean;
 


### PR DESCRIPTION
When trying to set the `autoComplete="off"` prop on `Combobox`(which is inherited from `TextField`), I get an error from the TS compiler saying:
```
(property) autoComplete?: undefined
Type 'string' is not assignable to type 'undefined'.ts(2322)
index.d.ts(615, 9): The expected type comes from property 'autoComplete' which is declared here on type 'IntrinsicAttributes & { autoComplete?: boolean | undefined; autoFocus?: boolean | undefined; className?: string | undefined; defaultValue?: string | undefined; ... 21 more ...; value?: string | undefined; } & Pick<...> & RefAttributes<...>'
```

I don't know why the type is reported as `undefined`, but the correct type should AFAIK be string, and not boolean https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete

This proposed change has not been tested, but I believe it would be ok to just remove the type for `autoComplete` declared on `TextField`, and simply inherit the type declared on `input`. WDYT?
