### PR TITLE
fix: support aria-label prop on affix component

### DIFF
--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -3,6 +3,9 @@ import { suffix, prefix } from '@fabric-ds/component-classes';
 import { classNames } from '@chbphone55/classnames';
 
 interface AffixProps {
+  /** Defines a string value that labels the affix element. */
+  'aria-label'?: string;
+
   /** Affix added at the beginning of input */
   prefix?: boolean;
 
@@ -28,6 +31,7 @@ export function Affix(props: AffixProps) {
   return React.createElement(
     props.label ? 'div' : 'button',
     {
+      'aria-label': props['aria-label'],
       onClick: props.onClick,
       className: classNames({
         [classBase.wrapper]: true,

--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -31,7 +31,7 @@ export function Affix(props: AffixProps) {
   return React.createElement(
     props.label ? 'div' : 'button',
     {
-      'aria-label': props['aria-label'],
+      'aria-label': !props.label ? props['aria-label'] : undefined,
       onClick: props.onClick,
       className: classNames({
         [classBase.wrapper]: true,
@@ -39,7 +39,7 @@ export function Affix(props: AffixProps) {
         [classBase.wrapperWithIcon]: !props.label,
       }),
     },
-    <div>
+    <>
       {props.clear && (
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -83,6 +83,6 @@ export function Affix(props: AffixProps) {
       )}
 
       {props.label && <span className={classBase.label}>{props.label}</span>}
-    </div>,
+    </>,
   );
 }

--- a/packages/combobox/docs/Combobox.mdx
+++ b/packages/combobox/docs/Combobox.mdx
@@ -200,11 +200,19 @@ function Example() {
         { value: 'Pineapple', label: '🍍 Pineapple' },
       ]}
     >
-      <Affix suffix clear onClick={() => setValue('')} />
+      <Affix
+        suffix
+        clear
+        aria-label="Clear text"
+        onClick={() => setValue('')}
+      />
     </Combobox>
   );
 }
 ```
+
+**Note** that when using the Affix component without a `label` you should
+specify an `aria-label`. See props at the bottom of this page.
 
 ### Clearing input on select
 


### PR DESCRIPTION
This PR adds support for labeling the `Affix` component with an `aria-label` attribute. This would make the search and clear buttons accessible to screen readers, since the buttons only contain an icon, and no descriptive text.

It would also be possible to add more props, like `aria-labelledby` and `aria-describedby`, according to the recommended guidelines https://www.w3.org/TR/wai-aria-practices-1.2/#button

Please feel free to suggest improvements to this PR while reviewing 😄 