### PR TITLE
fix: remove redundant div around textfield input

### DIFF
--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -25,26 +25,24 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     const helpId = helpText ? `${id}__hint` : undefined;
     const isInvalid = invalid || error;
 
+    const hasPrefix = children?.props.prefix;
+
     return (
       <div
         className={classNames({
           'input mb-0': true,
+          'input--is-invalid': isInvalid,
+          'input--is-disabled': disabled,
+          'input--is-read-only': readOnly,
           'has-suffix': children?.props.suffix,
-          'has-prefix': children?.props.prefix,
+          'has-prefix': hasPrefix,
         })}
       >
         {label && <label htmlFor={id}>{label}</label>}
-        <div
-          className={classNames(className, {
-            'input mb-0': true,
-            'input--is-invalid': isInvalid,
-            'input--is-disabled': disabled,
-            'input--is-read-only': readOnly,
-          })}
-          style={style}
-        >
+        <div className="relative">
           <input
             {...rest}
+            style={{ paddingLeft: hasPrefix && 37 }}
             aria-describedby={helpId}
             aria-errormessage={isInvalid && helpId ? helpId : undefined}
             aria-invalid={isInvalid}
@@ -54,13 +52,14 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             ref={ref}
             type={type}
           />
-          {helpText && (
-            <div className="input__sub-text" id={helpId}>
-              {helpText}
-            </div>
-          )}
           {children}
         </div>
+
+        {helpText && (
+          <div className="input__sub-text" id={helpId}>
+            {helpText}
+          </div>
+        )}
       </div>
     );
   },

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -26,6 +26,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     const isInvalid = invalid || error;
 
     const hasPrefix = children?.props.prefix;
+    const hasSuffix = children?.props.suffix;
 
     return (
       <div
@@ -34,7 +35,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           'input--is-invalid': isInvalid,
           'input--is-disabled': disabled,
           'input--is-read-only': readOnly,
-          'has-suffix': children?.props.suffix,
+          'has-suffix': hasSuffix,
           'has-prefix': hasPrefix,
         })}
       >
@@ -42,7 +43,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <div className="relative">
           <input
             {...rest}
-            style={{ paddingLeft: hasPrefix && 37 }}
+            style={{
+              paddingLeft: hasPrefix && 37,
+              paddingRight: hasSuffix && 37,
+            }}
             aria-describedby={helpId}
             aria-errormessage={isInvalid && helpId ? helpId : undefined}
             aria-invalid={isInvalid}

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -28,39 +28,38 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     return (
       <div
         className={classNames({
+          'input mb-0': true,
           'has-suffix': children?.props.suffix,
           'has-prefix': children?.props.prefix,
         })}
       >
-        <div className="input">
-          {label && <label htmlFor={id}>{label}</label>}
-          <div
-            className={classNames(className, {
-              'input mb-0': true,
-              'input--is-invalid': isInvalid,
-              'input--is-disabled': disabled,
-              'input--is-read-only': readOnly,
-            })}
-            style={style}
-          >
-            <input
-              {...rest}
-              aria-describedby={helpId}
-              aria-errormessage={isInvalid && helpId ? helpId : undefined}
-              aria-invalid={isInvalid}
-              disabled={disabled}
-              id={id}
-              readOnly={readOnly}
-              ref={ref}
-              type={type}
-            />
-            {helpText && (
-              <div className="input__sub-text" id={helpId}>
-                {helpText}
-              </div>
-            )}
-            {children}
-          </div>
+        {label && <label htmlFor={id}>{label}</label>}
+        <div
+          className={classNames(className, {
+            'input mb-0': true,
+            'input--is-invalid': isInvalid,
+            'input--is-disabled': disabled,
+            'input--is-read-only': readOnly,
+          })}
+          style={style}
+        >
+          <input
+            {...rest}
+            aria-describedby={helpId}
+            aria-errormessage={isInvalid && helpId ? helpId : undefined}
+            aria-invalid={isInvalid}
+            disabled={disabled}
+            id={id}
+            readOnly={readOnly}
+            ref={ref}
+            type={type}
+          />
+          {helpText && (
+            <div className="input__sub-text" id={helpId}>
+              {helpText}
+            </div>
+          )}
+          {children}
         </div>
       </div>
     );


### PR DESCRIPTION
This PR simplifies the DOM for the `TextField` component by removing the outermost `div`, which is redundant. All the examples in the storybook seem to be fine.