### PR TITLE
feat: support icon as textfield prefix/suffix

### DIFF
--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -86,3 +86,25 @@ export function Affix(props: AffixProps) {
     </>,
   );
 }
+
+interface IconAffixProps {
+  /** The icon SVG element */
+  children: React.ReactNode;
+
+  /** Affix added at the beginning of input */
+  prefix?: boolean;
+
+  /** Affix added at the end of input */
+  suffix?: boolean;
+}
+
+export function IconAffix(props: IconAffixProps) {
+  const classBase = props.prefix ? prefix : suffix;
+  const affixClass = `${classBase.wrapper} ${classBase.wrapperWithIcon}`;
+
+  return (
+    <div className={affixClass}>
+      <span className={classBase.label}>{props.children}</span>
+    </div>
+  );
+}

--- a/packages/_helpers/index.ts
+++ b/packages/_helpers/index.ts
@@ -1,3 +1,3 @@
 export { Clickable } from './clickable';
 export { DeadToggle } from './dead-toggle';
-export { Affix } from './affix';
+export { Affix, IconAffix } from './affix';

--- a/packages/textfield/stories/Textfield.stories.tsx
+++ b/packages/textfield/stories/Textfield.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import Search from '@fabric-ds/icons/react/search-16';
 import { action } from '@storybook/addon-actions';
+import React from 'react';
+import { Affix, IconAffix } from '../../_helpers';
 import { TextField as TroikaTextField } from '../src';
-import { Affix } from '../../_helpers';
 
 const metadata = { title: 'Forms/TextField' };
 export default metadata;
@@ -50,6 +51,14 @@ export const labelPrefix = () => (
   </TextField>
 );
 
+export const iconPrefix = () => (
+  <TextField>
+    <IconAffix prefix>
+      <Search />
+    </IconAffix>
+  </TextField>
+);
+
 export const clearSuffix = () => (
   <TextField>
     <Affix suffix clear onClick={() => alert('clear')} />
@@ -65,6 +74,14 @@ export const searchSuffix = () => (
 export const labelSuffix = () => (
   <TextField>
     <Affix suffix label="kr" />
+  </TextField>
+);
+
+export const iconSuffix = () => (
+  <TextField>
+    <IconAffix suffix>
+      <Search />
+    </IconAffix>
   </TextField>
 );
 


### PR DESCRIPTION
This PR adds a specialized kind of `Affix` component, that renders an icon as prefix/suffix in a `Textfield`.

I'm happy to discuss the interface for this new component. It would also be possible to split out the existing `Affix` into separate `LabelAffix` and `ButtonAffix` component, possibly making the code a bit clearer. Please let me know if you are open to discuss this idea, or if you prefer to incorporate icons in a different way (if at all).