### PR TITLE
fix: add button type attribute to affix buttons

### DIFF
--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -28,10 +28,19 @@ interface AffixProps {
 export function Affix(props: AffixProps) {
   const classBase = props.prefix ? prefix : suffix;
 
+  let buttonType;
+  if (props.search) {
+    buttonType = 'submit';
+  }
+  if (props.clear) {
+    buttonType = 'reset';
+  }
+
   return React.createElement(
     props.label ? 'div' : 'button',
     {
       'aria-label': !props.label ? props['aria-label'] : undefined,
+      type: buttonType,
       onClick: props.onClick,
       className: classNames({
         [classBase.wrapper]: true,

--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -28,19 +28,11 @@ interface AffixProps {
 export function Affix(props: AffixProps) {
   const classBase = props.prefix ? prefix : suffix;
 
-  let buttonType;
-  if (props.search) {
-    buttonType = 'submit';
-  }
-  if (props.clear) {
-    buttonType = 'reset';
-  }
-
   return React.createElement(
     props.label ? 'div' : 'button',
     {
       'aria-label': !props.label ? props['aria-label'] : undefined,
-      type: buttonType,
+      type: props.search ? 'submit' : props.clear ? 'reset' : undefined,
       onClick: props.onClick,
       className: classNames({
         [classBase.wrapper]: true,


### PR DESCRIPTION
This PR adds button type attributes to `Affix` buttons, specifically `type="submit"` for search, and `type="reset"` for clear. This prevents the clear button from submitting the enclosing form of the textfield.

I believe this code could be improved by extracting a separate `ButtonAffix` component as suggested in #76 .