### PR TITLE
fix: fix incorrect peer dep on React

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "17.0.3"
+    "react": "17.0.2"
   },
   "scripts": {
     "build:clean": "rm -rf dist",


### PR DESCRIPTION
17.0.3 does not exist. Should be 17.0.2 which is the current latest.