### PR TITLE
make slider trigger onChange also on click

### DIFF
--- a/packages/slider/src/RangeSlider.tsx
+++ b/packages/slider/src/RangeSlider.tsx
@@ -135,7 +135,7 @@ const RangeSlider = ({
     ({
       xy,
       first,
-      last,
+      active,
       memo = {
         rect: sliderRef.current?.getBoundingClientRect(),
         handle: Handle.Lower,
@@ -189,7 +189,16 @@ const RangeSlider = ({
         onInput(internalValue.current.concat() as [number, number]);
       }
 
-      if (last) {
+      if (!active) {
+        // When the user is dragging the slider, the useDrag callback is invoked multiple times,
+        // first with {first: true, active: true}, and finally with {last: true, active: false}.
+        //
+        // When the user is clicking (not dragging) the slider, the useDrag callback
+        // is invoked only once with {first: false, last: false, active: false}.
+        //
+        // We want to trigger onChange in both cases, and use {active: false} to detect when
+        // the user is done interacting with the filter (either clicking or dragging).
+
         setIsDragging(false);
         handleChange(dragValue, memo.handle);
         const ref =

--- a/packages/slider/src/RegularSlider.tsx
+++ b/packages/slider/src/RegularSlider.tsx
@@ -105,7 +105,7 @@ const RegularSlider = ({
     ({
       xy,
       first,
-      last,
+      active,
       memo = {
         rect: sliderRef.current?.getBoundingClientRect(),
       },
@@ -128,7 +128,16 @@ const RegularSlider = ({
 
       if (first) {
         setIsDragging(true);
-      } else if (last) {
+      } else if (!active) {
+        // When the user is dragging the slider, the useDrag callback is invoked multiple times,
+        // first with {first: true, active: true}, and finally with {last: true, active: false}.
+        //
+        // When the user is clicking (not dragging) the slider, the useDrag callback
+        // is invoked only once with {first: false, last: false, active: false}.
+        //
+        // We want to trigger onChange in both cases, and use {active: false} to detect when
+        // the user is done interacting with the filter (either clicking or dragging).
+
         setIsDragging(false);
         handleChange(dragValue);
         // focus the handle


### PR DESCRIPTION
This PR makes the slider call `onChange` also when the user clicks on the slider track, not just after dragging the slider thumbs.

Problem:
When clicking the slider track, `onChange` is not called, even though the input values are changed (and `onInput` is called). This prevents the eg. the search result page from updating the user's search when clicking on a slider filter.

Solution:
Since `active` is `true` while the user interacts with the slider, and `false` afterwards, we can use this state to trigger the `onChange´ callback.