### PR TITLE
docs: don't disable button on modal

### DIFF
--- a/packages/modal/docs/Modal.mdx
+++ b/packages/modal/docs/Modal.mdx
@@ -110,9 +110,17 @@ respond to `esc` keypresses and/or clicking outside the modal.
 ```jsx example
 function Example() {
   const [open, setOpen] = React.useState(false);
+  const [mustAgree, setMustAgree] = React.useState(false);
   const [hasAgreed, setHasAgreed] = React.useState(false);
 
-  const toggleModal = () => setOpen(!open);
+  const toggleModal = () => {
+    if (open && !hasAgreed) {
+      setMustAgree(true);
+      return;
+    }
+    setMustAgree(false);
+    setOpen(!open);
+  }
 
   return (
     <>
@@ -125,9 +133,12 @@ function Example() {
         onDismiss={hasAgreed ? toggleModal : undefined}
         title="Non dismissable"
         footer={
-          <Button primary disabled={!hasAgreed} onClick={toggleModal}>
-            Save
-          </Button>
+          <>
+            {mustAgree && <p className="m-10">You must agree first!</p>}
+            <Button primary onClick={toggleModal}>
+              Save
+            </Button>
+          </>
         }
       >
         <p>To go further, you need to agree to these bogus terms</p>


### PR DESCRIPTION
Changes from disable to displaying a message when clicking the button (in the case where the user hasn't clicked the checkbox)

Fixes https://github.com/fabric-ds/issues/issues/93