### PR TITLE
Add aria-label to Affix icons

### DIFF
--- a/packages/_helpers/affix.tsx
+++ b/packages/_helpers/affix.tsx
@@ -43,6 +43,8 @@ export function Affix(props: AffixProps) {
     <>
       {props.clear && (
         <svg
+          role="img"
+          aria-label="X"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
@@ -60,6 +62,8 @@ export function Affix(props: AffixProps) {
 
       {props.search && (
         <svg
+          role="img"
+          aria-label="Forstørrelsesglass"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"


### PR DESCRIPTION
Screen readers will use the aria-label on the SVG only if the button wrapper has no label. So in that sense, these default labels are like fallbacks.