### PR TITLE
feat: support multiple versions of react on Eik

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,13 +1,28 @@
+import { ok } from 'node:assert';
 import * as eik from '@eik/esbuild-plugin';
 import esbuild from 'esbuild';
 
-await eik.load();
+// maps React versions to import map file versions.
+// Add more mappings here when new versions of React become available.
+const versions = new Map([
+  ['16', 'v1'],
+  ['17', 'v2'],
+  ['18', 'v3'],
+]);
+
+const version = process.argv[2];
+const reactVersions = Array.from(versions.keys());
+ok(reactVersions.includes(version), `Version argument is required. Must be one of: ${reactVersions.join(',')}. Eg. 'node esbuild.mjs 18'`);
+
+await eik.load({
+  urls: [`https://assets.finn.no/map/react/${versions.get(version)}`],
+});
 
 await esbuild.build({
   plugins: [eik.plugin()],
   entryPoints: ['packages/index.ts'],
   bundle: true,
-  outdir: 'dist/eik',
+  outfile: `dist/eik/fabric-react-${version}.js`,
   format: 'esm',
   sourcemap: true,
   target: 'es2017',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "commit": "cz",
     "build:clean": "rm -rf dist",
-    "build:eik": "node esbuild.mjs",
+    "build:eik": "node esbuild.mjs 16 && node esbuild.mjs 17 && node esbuild.mjs 18",
     "build:types": "tsc && sed 's+declare module \"index\"+declare module \"@fabric-ds/react\"+g' ./dist/npm/index.d.ts > ./dist/npm/updated.d.ts && mv ./dist/npm/updated.d.ts ./dist/npm/index.d.ts",
     "build:npm": "npx esbuild ./packages/index.ts --outdir=dist/npm --target=es2017 --bundle --sourcemap --format=esm --external:react --minify",
     "build:node": "npx esbuild ./packages/index.ts --outdir=dist/npm --out-extension:.js=.cjs --target=es2017 --bundle --sourcemap --format=cjs --external:react --minify",
@@ -113,10 +113,7 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "package",
-    "files": "./dist/eik",
-    "import-map": [
-      "https://assets.finn.no/map/react/v2"
-    ]
+    "files": "./dist/eik"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This PR makes it so that whenever we publish a new version of Fabric React, we will also build Eik packages for each major version of React from 16 upwards. This is needed to make it so that we can support the use of Fabric React on different major versions of React. Each Eik import map then will contain a reference to the correct build.

The only thing that differs between builds is that bare imports of react are mapped to specific versions of React on the Eik server. eg. `import react from 'react'` is mapped to `import react from 'https://assets.finn.no/npm/react/v18/react.production.min.js'`

**Examples**
If a team is using React v17, they use the Eik import map `https://assets.finn.no/map/react/v2`which includes mappings for React v17 and will include a reference to the v17 version of Fabric React.

If a team is using React v18, they use the Eik import map `https://assets.finn.no/map/react/v3`which includes mappings for React v18 and will include a reference to the v18 version of Fabric React.
