### PR TITLE
fix: remove unused React v16 and add backwards compatible v17 bundle

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -5,7 +5,6 @@ import esbuild from 'esbuild';
 // maps React versions to import map file versions.
 // Add more mappings here when new versions of React become available.
 const versions = new Map([
-  ['16', 'v1'],
   ['17', 'v2'],
   ['18', 'v3'],
 ]);
@@ -17,6 +16,20 @@ ok(reactVersions.includes(version), `Version argument is required. Must be one o
 await eik.load({
   urls: [`https://assets.finn.no/map/react/${versions.get(version)}`],
 });
+
+// legacy support for older filenames
+if (version === '17') {
+  await esbuild.build({
+    plugins: [eik.plugin()],
+    entryPoints: ['packages/index.ts'],
+    bundle: true,
+    outfile: `dist/eik/index.js`,
+    format: 'esm',
+    sourcemap: true,
+    target: 'es2017',
+    minify: true,
+  });
+}
 
 await esbuild.build({
   plugins: [eik.plugin()],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "commit": "cz",
     "build:clean": "rm -rf dist",
-    "build:eik": "node esbuild.mjs 16 && node esbuild.mjs 17 && node esbuild.mjs 18",
+    "build:eik": "node esbuild.mjs 17 && node esbuild.mjs 18",
     "build:types": "tsc && sed 's+declare module \"index\"+declare module \"@fabric-ds/react\"+g' ./dist/npm/index.d.ts > ./dist/npm/updated.d.ts && mv ./dist/npm/updated.d.ts ./dist/npm/index.d.ts",
     "build:npm": "npx esbuild ./packages/index.ts --outdir=dist/npm --target=es2017 --bundle --sourcemap --format=esm --external:react --minify",
     "build:node": "npx esbuild ./packages/index.ts --outdir=dist/npm --out-extension:.js=.cjs --target=es2017 --bundle --sourcemap --format=cjs --external:react --minify",


### PR DESCRIPTION
There was no support for React v16 in 1.2.0 so no need to add it now so I have removed building a v16 bundle.
Additionally, I realised that by changing the name of index.js, I was actually causing a breaking change. To avoid that, I've created 2 bundles of v17. One is called index.js for backwards compatible reasons and one is called fabric-react-17.js for future proofing.