### PR TITLE
Fix Eik bundles to keep backwards compatibility with 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.1-next.1](https://github.com/fabric-ds/react/compare/v1.3.0...v1.3.1-next.1) (2022-06-21)
+
+
+### Bug Fixes
+
+* remove unused React v16 and add backwards compatible v17 bundle ([d23fa08](https://github.com/fabric-ds/react/commit/d23fa0814000de6dcbe8b9cfc0648fe771afe07c))
+
 # [1.3.0](https://github.com/fabric-ds/react/compare/v1.2.0...v1.3.0) (2022-06-20)
 
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -5,7 +5,6 @@ import esbuild from 'esbuild';
 // maps React versions to import map file versions.
 // Add more mappings here when new versions of React become available.
 const versions = new Map([
-  ['16', 'v1'],
   ['17', 'v2'],
   ['18', 'v3'],
 ]);
@@ -17,6 +16,20 @@ ok(reactVersions.includes(version), `Version argument is required. Must be one o
 await eik.load({
   urls: [`https://assets.finn.no/map/react/${versions.get(version)}`],
 });
+
+// legacy support for older filenames
+if (version === '17') {
+  await esbuild.build({
+    plugins: [eik.plugin()],
+    entryPoints: ['packages/index.ts'],
+    bundle: true,
+    outfile: `dist/eik/index.js`,
+    format: 'esm',
+    sourcemap: true,
+    target: 'es2017',
+    minify: true,
+  });
+}
 
 await esbuild.build({
   plugins: [eik.plugin()],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabric-ds/react",
-  "version": "1.3.0",
+  "version": "1.3.1-next.1",
   "repository": "git@github.com:fabric-ds/react.git",
   "license": "ISC",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "commit": "cz",
     "build:clean": "rm -rf dist",
-    "build:eik": "node esbuild.mjs 16 && node esbuild.mjs 17 && node esbuild.mjs 18",
+    "build:eik": "node esbuild.mjs 17 && node esbuild.mjs 18",
     "build:types": "tsc && sed 's+declare module \"index\"+declare module \"@fabric-ds/react\"+g' ./dist/npm/index.d.ts > ./dist/npm/updated.d.ts && mv ./dist/npm/updated.d.ts ./dist/npm/index.d.ts",
     "build:npm": "npx esbuild ./packages/index.ts --outdir=dist/npm --target=es2017 --bundle --sourcemap --format=esm --external:react --minify",
     "build:node": "npx esbuild ./packages/index.ts --outdir=dist/npm --out-extension:.js=.cjs --target=es2017 --bundle --sourcemap --format=cjs --external:react --minify",


### PR DESCRIPTION
We need to cut a release to remove a breaking change in the Eik bundles by adding a backwards compatible build. 