### PR TITLE
feat(expandable): make Expandable accept custom title

### DIFF
--- a/packages/expandable/docs/Expandable.mdx
+++ b/packages/expandable/docs/Expandable.mdx
@@ -1,3 +1,4 @@
+import { IconBag16 } from '@fabric-ds/icons/react';
 import { Expandable } from '../src';
 
 # Expandable
@@ -33,6 +34,23 @@ import { Expandable } from '@fabric-ds/react';
 
 ```jsx example
 <Expandable title="I am expandable" info box>
+  <p>Expandable contents go here.</p>
+</Expandable>
+```
+
+### Expandable info box with custom title
+
+```jsx example
+<Expandable
+  title={
+    <div className="flex flex-row items-center">
+      <IconBag16 />
+      <p className="ml-8 mb-0">This is a title with an icon</p>
+    </div>
+  }
+  box
+  info
+>
   <p>Expandable contents go here.</p>
 </Expandable>
 ```

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -50,33 +50,39 @@ export function Expandable(props: ExpandableProps) {
         })}
         onClick={() => toggleExpandable(stateExpanded)}
       >
-        {title && <span className="h4">{title}</span>}
-        {chevron && (
-          <div
-            className={classNames({
-              'inline-block align-middle transform transition-transform': true,
-              '-rotate-180': expanded,
-              'relative left-8': !box,
-              'box-chevron absolute right-16': box,
-            })}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="none"
-              viewBox="0 0 16 16"
+        <div className="flex justify-between align-center">
+          {typeof title === 'string' ? (
+            <span className="h4">{title}</span>
+          ) : (
+            title
+          )}
+          {chevron && (
+            <div
+              className={classNames({
+                'self-center transform transition-transform': true,
+                '-rotate-180': expanded,
+                'relative left-8': !box,
+                'box-chevron': box,
+              })}
             >
-              <path
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.5"
-                d="M2.5 5.5L8 11l5.5-5.5"
-              />
-            </svg>
-          </div>
-        )}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="none"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                  d="M2.5 5.5L8 11l5.5-5.5"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
       </button>
 
       <ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -1,3 +1,4 @@
+import { IconBag16 } from '@fabric-ds/icons/react';
 import * as React from 'react';
 import { Expandable } from '../src';
 
@@ -12,6 +13,21 @@ export const Default = () => (
 
 export const Box = () => (
   <Expandable title="This is a title" box>
+    <h1>I am expandable</h1>
+  </Expandable>
+);
+
+export const BoxWithCustomTitle = () => (
+  <Expandable
+    title={
+      <div className="flex flex-row items-center">
+        <IconBag16 />
+        <p className="ml-8 mb-0">This is a title with an icon</p>
+      </div>
+    }
+    box
+    info
+  >
     <h1>I am expandable</h1>
   </Expandable>
 );


### PR DESCRIPTION
Fixes [FRON-437](https://finn-jira.atlassian.net/jira/software/projects/FRON/boards/437?selectedIssue=FRON-635)

## Description
With this change it is possible to control Expandable's title style and add to it any additional React elements, like icons, without messing up chevron's alignment. `title` will be assigned a `h4` style as long as its type is `string`.

### title as string
<img width="620" alt="Screenshot 2022-06-22 at 13 05 15" src="https://user-images.githubusercontent.com/41303231/175014231-54743ede-38d7-4726-975a-b60cebddded4.png">

### title as icon and paragraph
<img width="629" alt="Screenshot 2022-06-22 at 12 57 17" src="https://user-images.githubusercontent.com/41303231/175012847-c4a8515a-3997-48d0-9f2e-28335dd3e999.png">
