### PR TITLE
fix(expandable): use local expanded state to control chevron's rotation

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -60,7 +60,7 @@ export function Expandable(props: ExpandableProps) {
             <div
               className={classNames({
                 'self-center transform transition-transform': true,
-                '-rotate-180': expanded,
+                '-rotate-180': stateExpanded,
                 'relative left-8': !box,
                 'box-chevron': box,
               })}


### PR DESCRIPTION
## Description

This change brings back rotation animation of `Expandable`'s chevron.

![chevron](https://user-images.githubusercontent.com/41303231/175030781-4142f2b7-73d7-42fb-8b37-c3bd208eb0c5.gif)

