### PR TITLE
Toggle - support invisible label option

### DIFF
--- a/packages/toggle/docs/Toggle.mdx
+++ b/packages/toggle/docs/Toggle.mdx
@@ -100,6 +100,30 @@ use the `selected` property instead (controlled).
 **Note** the `title` property. This gives you the option to label the options,
 but is not required.
 
+## Checkbox with invisible label
+
+You can hide the label by passing a `noVisibleLabel` prop to `Toggle` component.
+
+```jsx example
+function Example() {
+  const [checked, setChecked] = React.useState('No');
+  const answer = checked ? 'Yes' : 'No';
+
+  return (
+    <>
+      <p className="h4">Is checkbox selected? {answer}</p>
+      <Toggle
+        type="checkbox"
+        label={answer}
+        defaultChecked={checked}
+        onChange={(checked) => setChecked(checked)}
+        noVisibleLabel
+      />
+    </>
+  );
+}
+```
+
 ## Toggle with multiple options
 
 We've already had a look at checkboxes, but Toggle can also render radio options

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -80,6 +80,7 @@ export function Toggle(props: ToggleProps) {
             invalid={isInvalid}
             helpId={helpId}
             type={isRadioGroup ? 'radio' : 'checkbox'}
+            noVisibleLabel={props.noVisibleLabel}
           />
         ) : (
           props.options &&
@@ -98,6 +99,7 @@ export function Toggle(props: ToggleProps) {
               invalid={isInvalid}
               helpId={helpId}
               type={isRadioGroup ? 'radio' : 'checkbox'}
+              noVisibleLabel={props.noVisibleLabel}
             />
           ))
         )}

--- a/packages/toggle/src/index.ts
+++ b/packages/toggle/src/index.ts
@@ -1,2 +1,3 @@
 export { Toggle } from './component';
+export { Item as ToggleItem } from './item';
 export type { ToggleProps } from './props';

--- a/packages/toggle/src/index.ts
+++ b/packages/toggle/src/index.ts
@@ -1,3 +1,2 @@
 export { Toggle } from './component';
-export { Item as ToggleItem } from './item';
 export type { ToggleProps } from './props';

--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -11,6 +11,7 @@ interface ItemProps extends Pick<HTMLInputElement, 'type' | 'name'> {
   defaultChecked?: boolean;
   invalid?: boolean;
   helpId?: string;
+  noVisibleLabel?: boolean;
   label?: string;
   className?: string;
   labelClassName?: string;
@@ -27,12 +28,13 @@ export function Item({
   helpId,
   checked,
   defaultChecked,
+  noVisibleLabel,
   labelClassName,
   ...props
 }: ItemProps) {
   const id = useId();
 
-  return (
+  const item = (
     <>
       <input
         id={id}
@@ -54,8 +56,20 @@ export function Item({
       />
 
       <label htmlFor={id} className={labelClassName}>
-        {!children ? label || option?.label : children}
+        {noVisibleLabel ? (
+          <span className="invisible w-0">{label}</span>
+        ) : !children ? (
+          label || option?.label
+        ) : (
+          children
+        )}
       </label>
     </>
+  );
+
+  return (
+    <React.Fragment>
+      {noVisibleLabel ? <div className="input-toggle">{item}</div> : item}
+    </React.Fragment>
   );
 }

--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -34,7 +34,9 @@ export function Item({
 }: ItemProps) {
   const id = useId();
 
-  const item = (
+  const labelContent = !children ? label || option?.label : children;
+
+  return (
     <>
       <input
         id={id}
@@ -57,19 +59,11 @@ export function Item({
 
       <label htmlFor={id} className={labelClassName}>
         {noVisibleLabel ? (
-          <span className="invisible w-0">{label}</span>
-        ) : !children ? (
-          label || option?.label
+          <span className="invisible w-0">{labelContent}</span>
         ) : (
-          children
+          labelContent
         )}
       </label>
     </>
-  );
-
-  return (
-    <React.Fragment>
-      {noVisibleLabel ? <div className="input-toggle">{item}</div> : item}
-    </React.Fragment>
   );
 }

--- a/packages/toggle/src/props.ts
+++ b/packages/toggle/src/props.ts
@@ -79,4 +79,9 @@ export interface ToggleProps {
    * Custom classes applied to the wrapping container
    */
   className?: string;
+
+  /**
+   * Whether label should be invisible
+   */
+  noVisibleLabel?: boolean;
 }

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Toggle } from '../src';
+import { useState } from 'react';
+import { Toggle, ToggleItem } from '../src';
 
 const metadata = { title: 'Forms/Toggle/Checkbox' };
 export default metadata;
@@ -9,6 +9,22 @@ const options = [
   { label: 'Microsoft', value: 'microsoft' },
   { label: 'Amazon', value: 'amazon' },
 ];
+
+export const ToggleItemExample = () => {
+  const [value, setValue] = useState(false);
+
+  return (
+    <ToggleItem
+      onChange={() => setValue(!value)}
+      checked={value}
+      type="checkbox"
+      name="privacy-enabled"
+      label="Toggle X"
+      noVisibleLabel={true}
+      controlled={true}
+    />
+  );
+};
 
 export const SingleOption = () => {
   return (

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Toggle, ToggleItem } from '../src';
+import { Toggle } from '../src';
 
 const metadata = { title: 'Forms/Toggle/Checkbox' };
 export default metadata;
@@ -10,18 +10,16 @@ const options = [
   { label: 'Amazon', value: 'amazon' },
 ];
 
-export const ToggleItemExample = () => {
+export const SingleOptionWithInvisibleLabel = () => {
   const [value, setValue] = useState(false);
 
   return (
-    <ToggleItem
+    <Toggle
       onChange={() => setValue(!value)}
       checked={value}
       type="checkbox"
-      name="privacy-enabled"
       label="Toggle X"
-      noVisibleLabel={true}
-      controlled={true}
+      noVisibleLabel
     />
   );
 };


### PR DESCRIPTION
Fixes [FRON-640](https://finn-jira.atlassian.net/browse/FRON-640?atlOrigin=eyJpIjoiNjBhZjI4MWQyYWIwNGRiYTg0ZTk5NmZkM2ZmZjFhNTAiLCJwIjoiaiJ9)

## Description
Make it possible to hide label in `Toggle` component .

![checkboxWithoutLabel](https://user-images.githubusercontent.com/41303231/177158380-a5dee619-2beb-4ab8-b4dd-7b8a51d3e10a.gif)

### Comments
Me and @benja discussed a possibility to export the `Item` component instead but we agreed that it might be a better idea not to export a separate component from the library, but rather add a feature to hide label from the main `Toggle` component.
