### PR TITLE
fix(card): Add button type to sr-only button

### DIFF
--- a/packages/card/src/component.tsx
+++ b/packages/card/src/component.tsx
@@ -33,7 +33,7 @@ export function Card(props: CardProps) {
     },
     <>
       {props.onClick && (
-        <button className="sr-only" aria-pressed={props.selected} tabIndex={-1}>
+        <button className="sr-only" aria-pressed={props.selected} tabIndex={-1} type="button">
           Velg
         </button>
       )}


### PR DESCRIPTION
Without type="button", it becomes a submit button by default, causing parent form (if any) to prematurely submit when a screen reader simulates a click on the button.