### PR TITLE
feat(alert): improve accessibility of the Alert component and docs

### DIFF
--- a/packages/_helpers/expand-transition.tsx
+++ b/packages/_helpers/expand-transition.tsx
@@ -39,7 +39,7 @@ export function ExpandTransition({
 
   return (
     <div ref={expandableRef} aria-hidden={!show ? true : undefined}>
-      {removeElement ? <React.Fragment /> : children}
+      {removeElement ? null : children}
     </div>
   );
 }

--- a/packages/_helpers/expand-transition.tsx
+++ b/packages/_helpers/expand-transition.tsx
@@ -38,7 +38,7 @@ export function ExpandTransition({
   }, [show]);
 
   return (
-    <div ref={expandableRef} aria-hidden={!show}>
+    <div ref={expandableRef} aria-hidden={!show ? true : undefined}>
       {removeElement ? <React.Fragment /> : children}
     </div>
   );

--- a/packages/_helpers/expand-transition.tsx
+++ b/packages/_helpers/expand-transition.tsx
@@ -1,25 +1,24 @@
 import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { collapse, expand } from 'element-collapse';
-import { classNames } from '@chbphone55/classnames';
 
 export function ExpandTransition({
   show,
   children,
 }: PropsWithChildren<{ show?: Boolean }>) {
-  const [isExpanded, setIsExpanded] = useState(show);
+  const [removeElement, setRemoveElement] = useState(!show);
   const expandableRef = useRef<HTMLDivElement>(null);
   const isMounted = useRef(false);
 
-  async function collapseElement(el: HTMLElement) {
-    await new Promise((resolve) => {
-      collapse(el, resolve);
-    });
-    setIsExpanded(false);
+  function collapseElement(el: HTMLElement) {
+    collapse(el, () => setRemoveElement(true));
   }
 
   function expandElement(el: HTMLElement) {
     expand(el);
-    setIsExpanded(true);
+  }
+
+  if (show && removeElement) {
+    setRemoveElement(false);
   }
 
   useEffect(() => {
@@ -39,15 +38,8 @@ export function ExpandTransition({
   }, [show]);
 
   return (
-    <div
-      ref={expandableRef}
-      className={classNames({
-        'overflow-hidden': true,
-        'h-0 invisible': !isExpanded,
-      })}
-      aria-hidden={!isExpanded}
-    >
-      {children}
+    <div ref={expandableRef} aria-hidden={!show}>
+      {removeElement ? <React.Fragment /> : children}
     </div>
   );
 }

--- a/packages/alert/docs/Alert.mdx
+++ b/packages/alert/docs/Alert.mdx
@@ -80,6 +80,52 @@ function ExpandableAlert() {
 </Alert>
 ```
 
+## Accessibility
+
+Use the ARIA live region `role` attribute to provide meaning to the alert
+element (defaults to "alert"). If you want to remove the role from the alert and
+assign it to its particular child (e.g. title), you can do so by setting `role`
+property of the `Alert` component to an empty string and assigning a respective
+`role` attribute on the child element. Read more about live region `role`
+attribute on
+[MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes).
+
+### Alert with "alert" role on a descendand element
+
+```jsx example
+function ExpandableAlertWithOverridenRole() {
+  const [show, setShow] = React.useState(true);
+
+  return (
+    <>
+      <Button
+        className="mb-16"
+        small
+        primary
+        onClick={() => setShow(!show)}
+        aria-controls="example-alert"
+        aria-expanded={show}
+      >
+        {show ? 'Hide alert' : 'Show alert'}
+      </Button>
+      <Alert id="example-alert" type="info" show={show} role="">
+        <p role="alert" className="font-bold">
+          This title should be read
+        </p>
+        <p>This is the message text that can be short or a little bit long</p>
+        <a>Link to more information</a>
+        <div className="mt-8 space-x-8">
+          <Button small>Primary CTA</Button>
+          <Button small secondary quiet>
+            Secondary
+          </Button>
+        </div>
+      </Alert>
+    </>
+  );
+}
+```
+
 ## Props
 
 ```props packages/alert/src/component.tsx

--- a/packages/alert/docs/Alert.mdx
+++ b/packages/alert/docs/Alert.mdx
@@ -25,21 +25,24 @@ function ExpandableAlert() {
         className="mb-16"
         small
         primary
-        onClick={() => setShow(!show)}
+        onClick={() => {
+          setShow(false);
+          setTimeout(() => setShow(true), 500);
+        }}
         aria-controls="example-alert"
         aria-expanded={show}
       >
-        {show ? 'Hide alert' : 'Show alert'}
+        Hide and show "info" variant of the alert
       </Button>
 
       <Alert id="example-alert" type="info" show={show}>
-        <p className="font-bold">Title Caption-Strong</p>
-        <p>This is the message text that can be short or a little bit long</p>
-        <a>Link to more information</a>
+        <p className="font-bold">This is "info" variant of the alert element</p>
+        <p>With an additional description</p>
+        <a>And a link to more information</a>
         <div className="mt-8 space-x-8">
-          <Button small>Primary CTA</Button>
+          <Button small>Primary button</Button>
           <Button small secondary quiet>
-            Secondary
+            Secondary button
           </Button>
         </div>
       </Alert>
@@ -52,7 +55,7 @@ function ExpandableAlert() {
 
 ```jsx example
 <Alert type="negative" show>
-  This is the message text that can be short or a little bit long
+  This is "negative" variant of the alert element
 </Alert>
 ```
 
@@ -60,7 +63,7 @@ function ExpandableAlert() {
 
 ```jsx example
 <Alert type="positive" show>
-  This is the message text that can be short or a little bit long
+  This is "positive" variant of the alert element
 </Alert>
 ```
 
@@ -68,7 +71,7 @@ function ExpandableAlert() {
 
 ```jsx example
 <Alert type="warning" show>
-  This is the message text that can be short or a little bit long
+  This is "warning" variant of the alert element
 </Alert>
 ```
 
@@ -76,7 +79,7 @@ function ExpandableAlert() {
 
 ```jsx example
 <Alert type="info" show>
-  This is the message text that can be short or a little bit long
+  This is "info" variant of the alert element
 </Alert>
 ```
 
@@ -102,22 +105,25 @@ function ExpandableAlertWithOverridenRole() {
         className="mb-16"
         small
         primary
-        onClick={() => setShow(!show)}
-        aria-controls="example-alert"
+        onClick={() => {
+          setShow(false);
+          setTimeout(() => setShow(true), 500);
+        }}
+        aria-controls="example2-alert"
         aria-expanded={show}
       >
-        {show ? 'Hide alert' : 'Show alert'}
+        Hide and show alert
       </Button>
-      <Alert id="example-alert" type="info" show={show} role="">
+      <Alert id="example2-alert" type="info" show={show} role="">
         <p role="alert" className="font-bold">
-          This title should be read
+          This is "info" variant of the alert element
         </p>
-        <p>This is the message text that can be short or a little bit long</p>
-        <a>Link to more information</a>
+        <p>With an additional description</p>
+        <a>And a link to more information</a>
         <div className="mt-8 space-x-8">
-          <Button small>Primary CTA</Button>
+          <Button small>Primary button</Button>
           <Button small secondary quiet>
-            Secondary
+            Secondary button
           </Button>
         </div>
       </Alert>

--- a/packages/alert/docs/Alert.mdx
+++ b/packages/alert/docs/Alert.mdx
@@ -21,7 +21,18 @@ function ExpandableAlert() {
 
   return (
     <>
-      <Alert type="info" show={show}>
+      <Button
+        className="mb-16"
+        small
+        primary
+        onClick={() => setShow(!show)}
+        aria-controls="example-alert"
+        aria-expanded={show}
+      >
+        {show ? 'Hide alert' : 'Show alert'}
+      </Button>
+
+      <Alert id="example-alert" type="info" show={show}>
         <p className="font-bold">Title Caption-Strong</p>
         <p>This is the message text that can be short or a little bit long</p>
         <a>Link to more information</a>
@@ -32,10 +43,6 @@ function ExpandableAlert() {
           </Button>
         </div>
       </Alert>
-
-      <Button className="mt-16" small primary onClick={() => setShow(!show)}>
-        {show ? 'Hide alert' : 'Show alert'}
-      </Button>
     </>
   );
 }

--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -6,6 +6,7 @@ import { ExpandTransition } from '../../_helpers';
 export function Alert({
   show,
   type,
+  role = 'alert',
   children,
   ...props
 }: PropsWithChildren<AlertProps>) {
@@ -14,13 +15,19 @@ export function Alert({
   return (
     <ExpandTransition show={show}>
       <div
+        role={role}
         className={classNames(
           props.className,
           `flex p-16 border rounded-4 border-l-4 bg-${color}-50 border-${color}-300`,
         )}
         style={{ borderLeftColor: `var(--f-${color}-600)`, ...props.style }}
       >
-        <div className={`w-16 mr-8 text-${color}-600`} style={{ minWidth: '16px' }}>{icon}</div>
+        <div
+          className={`w-16 mr-8 text-${color}-600`}
+          style={{ minWidth: '16px' }}
+        >
+          {icon}
+        </div>
         <div className="last-child:mb-0 text-14">{children}</div>
       </div>
     </ExpandTransition>

--- a/packages/alert/src/props.tsx
+++ b/packages/alert/src/props.tsx
@@ -8,6 +8,10 @@ export type AlertProps = {
    */
   type: 'negative' | 'positive' | 'warning' | 'info';
   /**
+   * ARIA live region "role" attribute value
+   */
+  role: string;
+  /**
    * Additional classes to include
    */
   className?: string;

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -110,7 +110,7 @@ function ExpansionBehaviour({ animated, stateExpanded, children }) {
         'overflow-hidden': true,
         'h-0 invisible': !stateExpanded,
       })}
-      aria-hidden={!stateExpanded}
+      aria-hidden={!stateExpanded ? true : undefined}
     >
       {children}
     </div>


### PR DESCRIPTION
## Description
Make React `Alert` consistent with Elements `f-alert` in terms of accessibility:
- set default "alert" role in `Alert` component
- handle elements with "alert" role nested in `Alert` component, so that screen readers recognize them
- improve the accessibility of Alert component docs

### Additionally
- As it was applied in Fabric Elements, `ExpandTransition` component now renders `children` only if `show` property value is `true`