### PR TITLE
Bugfix - attention position

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@fabric-ds/core": "0.0.13",
+    "@fabric-ds/core": "0.0.15",
     "@fabric-ds/css": "^1.1.4",
     "d3-scale": "^4.0.2",
     "react-focus-lock": "^2.5.2",

--- a/packages/attention/src/component.tsx
+++ b/packages/attention/src/component.tsx
@@ -20,7 +20,10 @@ export function Attention(props: AttentionProps) {
   } = props;
 
   const [actualDirection, setActualDirection] = useState(placement);
+  // Don't show attention element before its position is computed on first render
+  const [isVisible, setIsVisible] = useState<Boolean | undefined>(false);
 
+  const isMounted = useRef(true);
   const attentionRef = useRef<HTMLDivElement | null>(null);
   const arrowRef = useRef<HTMLDivElement | null>(null);
 
@@ -62,13 +65,26 @@ export function Attention(props: AttentionProps) {
     recompute(attentionState);
   });
 
+  useEffect(() => {
+    if (isMounted.current) {
+      isMounted.current = false;
+
+      // update attention's visibility after first render if showing by default or it's of type callout
+      if (isShowing === true || props.callout) {
+        setIsVisible(isShowing);
+      }
+    } else {
+      setIsVisible(isShowing);
+    }
+  }, [isShowing, props.callout]);
+
   return (
     <div
       className={classNames(
         {
           'absolute z-50': !props.callout,
-          invisible: !isShowing && !props.callout,
-          hidden: !isShowing && !props.tooltip,
+          invisible: !isVisible && !props.callout,
+          hidden: !isVisible && !props.tooltip,
         },
         className,
       )}

--- a/packages/attention/src/component.tsx
+++ b/packages/attention/src/component.tsx
@@ -4,6 +4,7 @@ import {
   opposites,
   rotation,
   useRecompute as recompute,
+  arrowLabels,
 } from '@fabric-ds/core/attention';
 import { attention as c } from '@fabric-ds/css/component-classes';
 import { ArrowProps, AttentionProps } from './props';
@@ -114,6 +115,7 @@ const Arrow = forwardRef<HTMLDivElement, ArrowProps>((props, ref) => {
 
   return (
     <div
+      aria-label={arrowLabels[arrowDirection]}
       ref={ref}
       className={classNames({
         [c.arrowBase]: true,


### PR DESCRIPTION
## Description
Fixes an issue with `Attention`'s position on first render reported in https://sch-chat.slack.com/archives/C01GYKPJVFT/p1660561211389669

![attention-position](https://user-images.githubusercontent.com/41303231/184650494-92dd7483-07bd-4a87-a023-d6b587551239.gif)

## Additionally
Adds aria labels to `Arrow` component