### PR TITLE
Listen for "expanded" prop change if it's updated outside of Expandable

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -27,6 +27,10 @@ export function Expandable(props: ExpandableProps) {
 
   const [stateExpanded, setStateExpanded] = React.useState(expanded);
 
+  React.useEffect(() => {
+    setStateExpanded(expanded);
+  }, [expanded]);
+
   const toggleExpandable = (state) => {
     setStateExpanded(!state);
     if (onChange) onChange(!state);


### PR DESCRIPTION
Fixes an issue where contents didn’t expand if `expanded` prop was updated outside of `Expandable`, e.g. by another button.

Before:
![expandable-bug](https://user-images.githubusercontent.com/41303231/184874446-01a7c4ad-d9f5-42fc-97f4-4bcd9657fe92.gif)


After:
![expandable](https://user-images.githubusercontent.com/41303231/184874427-62bdc954-5f33-4cc1-bfa8-ece0eecd76d4.gif)
