### PR TITLE
fix(expandable): set button type to 'button' to prevent default submit behaviour

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -47,6 +47,7 @@ export function Expandable(props: ExpandableProps) {
     >
       <UnstyledHeading level={headingLevel}>
         <button
+          type='button'
           aria-expanded={stateExpanded}
           className={classNames({
             [buttonClass || '']: true,


### PR DESCRIPTION
Unexpected behaviour of the `Expandable` component.
When Expandable is inside the `<form/>` element it triggers its submit on click.

Reproduced here: [Sandbox](https://codesandbox.io/s/fabric-expandable-submit-mm4gbs?file=/src/App.jsx)
As can be seen on the sandbox the submit handler fires on Expandable click.

The bug probably is due to the missing type="button" attribute within <button/> used inside the Expandable component. Default value of type is submit therefore causing the form submit.
