### PR TITLE
fix(alert): type 'role' prop as optional

### DIFF
--- a/packages/alert/src/props.tsx
+++ b/packages/alert/src/props.tsx
@@ -10,7 +10,7 @@ export type AlertProps = {
   /**
    * ARIA live region "role" attribute value
    */
-  role: string;
+  role?: string;
   /**
    * Additional classes to include
    */


### PR DESCRIPTION
`role` prop of `Alert` component has a default value so it shouldn't be required.