### PR TITLE
fix: remove additional hidden label

### DIFF
--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -59,10 +59,7 @@ export function Item({
 
       <label htmlFor={id} className={labelClassName}>
         {noVisibleLabel ? (
-          <>
-            <span className="invisible w-0">{labelContent}</span>
-            <span className="sr-only">{labelContent}</span>
-          </>
+          <span className="sr-only">{labelContent}</span>
         ) : (
           labelContent
         )}


### PR DESCRIPTION
The additional invisible label span was causing space to be reserved and upon discussion it seems like the only need for an invisible label is for screen readers and that's already covered by the sr-only span. It seems like we can just remove the invisible w-0 span.
@martin-storsletten are you able to sense check this change?