### PR TITLE
fix: remove unused react-spring dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-dom": "16.14.0",
     "react-focus-lock": "^2.5.2",
     "react-router-dom": "^5.2.0",
-    "react-spring": "^8.0.27",
     "rehype-stringify": "^8.0.0",
     "remark-autolink-headings": "^6.0.1",
     "remark-parse": "^9.0.0",
@@ -106,7 +105,6 @@
     "@fabric-ds/css": "^1.1.4",
     "d3-scale": "^4.0.2",
     "react-focus-lock": "^2.5.2",
-    "react-spring": "^9.0.0",
     "resize-observer-polyfill": "^1.5.1",
     "scroll-doctor": "^1.0.0"
   },


### PR DESCRIPTION
Not only was this not being used but we were including it in both deps and devdeps at the same time with 2 different major versions 🤦 