### PR TITLE
fix(breadcrumbs): handle array of nodes passed as children

### DIFF
--- a/packages/breadcrumbs/src/component.tsx
+++ b/packages/breadcrumbs/src/component.tsx
@@ -7,6 +7,9 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
   const { children, className, ...rest } = props;
   const ariaLabel = props['aria-label'] || 'Her er du';
 
+  // Handles array of nodes passed as children
+  const flattenedNodes = children.flat();
+
   return (
     <nav
       className={classNames('flex space-x-8 space-x-reverse', className)}
@@ -15,7 +18,7 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
     >
       <h2 className="sr-only">{ariaLabel}</h2>
       {interleave(
-        children,
+        flattenedNodes,
         <span aria-hidden className="select-none">
           /
         </span>,

--- a/packages/breadcrumbs/src/component.tsx
+++ b/packages/breadcrumbs/src/component.tsx
@@ -7,8 +7,8 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
   const { children, className, ...rest } = props;
   const ariaLabel = props['aria-label'] || 'Her er du';
 
-  // Handles array of nodes passed as children
-  const flattenedNodes = children.flat();
+  // Handles arrays of nodes passed as children
+  const flattenedChildren = children.flat(Infinity);
 
   return (
     <nav
@@ -18,7 +18,7 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
     >
       <h2 className="sr-only">{ariaLabel}</h2>
       {interleave(
-        flattenedNodes,
+        flattenedChildren,
         <span aria-hidden className="select-none">
           /
         </span>,

--- a/packages/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -31,3 +31,64 @@ export const ExampleWithArray = () => {
     </Breadcrumbs>
   );
 };
+
+type BreadcrumbsLink = { id: number; name: string };
+
+export const ExampleWithNestedArrays = () => {
+  const breadcrumbs = [
+    { id: 1, name: 'Item 1' },
+    { id: 2, name: 'Item 2' },
+    { id: 3, name: 'Item 3' },
+    { id: 4, name: 'Item 4' },
+    [
+      { id: 5, name: 'Item 5' },
+      { id: 6, name: 'Item 6' },
+      [
+        { id: 7, name: 'Item 7' },
+        { id: 8, name: 'Item 8' },
+      ],
+    ],
+    { id: 0, name: 'Item 9' },
+  ];
+
+  const lastItem = breadcrumbs.at(-1) as BreadcrumbsLink;
+
+  return (
+    <Breadcrumbs>
+      {breadcrumbs
+        .slice(0, -1)
+        .map(
+          (
+            collection:
+              | BreadcrumbsLink
+              | Array<BreadcrumbsLink | BreadcrumbsLink[]>,
+          ) => {
+            if ('name' in collection) {
+              return (
+                <a href={`?id=${collection.id}`} key={`?id=${collection.id}`}>
+                  {collection.name}
+                </a>
+              );
+            }
+
+            return collection.map((coll) => {
+              if ('name' in coll) {
+                return (
+                  <a href={`?id=${coll.id}`} key={`?id=${coll.id}`}>
+                    {coll.name}
+                  </a>
+                );
+              }
+
+              return coll.map((c) => (
+                <a href={`?id=${c.id}`} key={`?id=${c.id}`}>
+                  {c.name}
+                </a>
+              ));
+            });
+          },
+        )}
+      <span aria-current="page">{lastItem.name}</span>
+    </Breadcrumbs>
+  );
+};

--- a/packages/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -4,10 +4,30 @@ import { Breadcrumbs } from '../src';
 const metadata = { title: 'Navigation/Breadcrumbs' };
 export default metadata;
 
-export const Example = () => (
+export const BasicExample = () => (
   <Breadcrumbs>
     <a href="#/url1">Item 1</a>
     <a href="#/url2">Item 2</a>
     <a href="#/url3">Item 3</a>
   </Breadcrumbs>
 );
+
+export const ExampleWithArray = () => {
+  const breadcrumbs = [
+    { id: 1, name: 'Item 1' },
+    { id: 2, name: 'Item 2' },
+    { id: 3, name: 'Item 3' },
+    { id: 4, name: 'Item 4' },
+  ];
+
+  return (
+    <Breadcrumbs>
+      {breadcrumbs.slice(0, -1).map((collection) => (
+        <a href={`?id=${collection.id}`} key={`?id=${collection.id}`}>
+          {collection.name}
+        </a>
+      ))}
+      <span aria-current="page">{breadcrumbs.at(-1)!.name}</span>
+    </Breadcrumbs>
+  );
+};


### PR DESCRIPTION
Fixes https://github.com/fabric-ds/issues/issues/115

Flatten children array before calling interleave to ensure correct display of breadcrumbs.

Before:
<img width="237" alt="Screenshot 2022-11-03 at 09 26 47" src="https://user-images.githubusercontent.com/41303231/199675674-a8ef0cdd-c563-4729-8974-14a537ac2358.png">

After:
<img width="255" alt="Screenshot 2022-11-03 at 09 27 24" src="https://user-images.githubusercontent.com/41303231/199675761-f1e1ca0f-310d-41b1-89a1-b32b1fd3d007.png">
