### PR TITLE
Fix attention docs

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
 <link
-  href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+  href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
   rel="stylesheet"
 />

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       }
     </style>
     <link
-      href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+      href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
       rel="stylesheet"
     />
     <link

--- a/packages/attention/docs/Attention.mdx
+++ b/packages/attention/docs/Attention.mdx
@@ -86,7 +86,12 @@ function Example() {
       >
         Open menu
       </Button>
-      <Attention popver placement="bottom" targetEl={targetEl} isShowing={show}>
+      <Attention
+        popover
+        placement="bottom"
+        targetEl={targetEl}
+        isShowing={show}
+      >
         <ul className="bg-white w-full text-center">
           <li
             tabIndex={0}

--- a/packages/attention/stories/Attention.stories.tsx
+++ b/packages/attention/stories/Attention.stories.tsx
@@ -75,7 +75,12 @@ export function Popover() {
       >
         Open menu
       </Button>
-      <Attention popver placement="bottom" targetEl={targetEl} isShowing={show}>
+      <Attention
+        popover
+        placement="bottom"
+        targetEl={targetEl}
+        isShowing={show}
+      >
         <ul className="bg-white w-full text-center">
           <li
             tabIndex={0}

--- a/tests/eik-react-jsx/index.html
+++ b/tests/eik-react-jsx/index.html
@@ -5,7 +5,7 @@
     <title>Fabric React</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
-      href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+      href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
       rel="stylesheet"
     />
   </head>

--- a/tests/eik-react/index.html
+++ b/tests/eik-react/index.html
@@ -5,7 +5,7 @@
     <title>Fabric React</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
-      href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+      href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css"
       rel="stylesheet"
     />
   </head>

--- a/tests/ssr-react-16-cjs/src/server.js
+++ b/tests/ssr-react-16-cjs/src/server.js
@@ -22,7 +22,7 @@ server.get('/', (request, reply) => {
         <meta charset="UTF-8" />
         <title>Fabric React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css" rel="stylesheet" />
+        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css" rel="stylesheet" />
       </head>
       <body>
         <div id="app">${markup}</div>

--- a/tests/ssr-react-16/server.js
+++ b/tests/ssr-react-16/server.js
@@ -25,7 +25,7 @@ server.get('/', (request, reply) => {
         <meta charset="UTF-8" />
         <title>Fabric React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css" rel="stylesheet" />
+        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css" rel="stylesheet" />
       </head>
       <body>
         <div id="app">${markup}</div>

--- a/tests/ssr-react-ts-16-cjs/src/server.ts
+++ b/tests/ssr-react-ts-16-cjs/src/server.ts
@@ -23,7 +23,7 @@ server.get('/', (request, reply) => {
         <meta charset="UTF-8" />
         <title>Fabric React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css" rel="stylesheet" />
+        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css" rel="stylesheet" />
       </head>
       <body>
         <div id="app">${markup}</div>

--- a/tests/ssr-react-ts-16/src/server.ts
+++ b/tests/ssr-react-ts-16/src/server.ts
@@ -26,7 +26,7 @@ server.get('/', (request, reply) => {
         <meta charset="UTF-8" />
         <title>Fabric React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css" rel="stylesheet" />
+        <link href="https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css" rel="stylesheet" />
       </head>
       <body>
         <div id="app">${markup}</div>


### PR DESCRIPTION
Before:
<img width="179" alt="Screenshot 2022-11-08 at 17 26 35" src="https://user-images.githubusercontent.com/41303231/200620694-3ce37d28-890c-4b64-8dca-c4f55545b7b8.png">

After:
<img width="245" alt="Screenshot 2022-11-08 at 17 26 23" src="https://user-images.githubusercontent.com/41303231/200620722-58b35f1a-4c24-41b2-8514-4cce1407573c.png">

Also bumped Fabric css version to v1 so that `drop-shadow-20` class of popover Attention could be applied.