### PR TITLE
fix(modal): fix missing target error from react-focus-lock on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [1.5.0](https://github.com/fabric-ds/react/compare/v1.4.2...v1.5.0) (2022-11-21)
+
+
+### Bug Fixes
+
+* **breadcrumbs:** handle array of nodes passed as children ([04728d9](https://github.com/fabric-ds/react/commit/04728d9782f73664552d3e4d1121a7a479b10253))
+* **Card:** fix toggle-in-card navigation ([#165](https://github.com/fabric-ds/react/issues/165)) ([fd03fc6](https://github.com/fabric-ds/react/commit/fd03fc6956142923103cc2a5e2c771fd42637335))
+
+
+### Features
+
+* **toggle:** handle indeterminate state in a select-all checkbox ([#161](https://github.com/fabric-ds/react/issues/161)) ([af1970b](https://github.com/fabric-ds/react/commit/af1970b5dfe1ab87d061292065ddd18c942e2855))
+
 # [1.5.0-next.2](https://github.com/fabric-ds/react/compare/v1.5.0-next.1...v1.5.0-next.2) (2022-11-09)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabric-ds/react",
-  "version": "1.5.0-next.2",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabric-ds/react",
-      "version": "1.5.0-next.2",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@chbphone55/classnames": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabric-ds/react",
-  "version": "1.5.0-next.2",
+  "version": "1.5.0",
   "repository": "git@github.com:fabric-ds/react.git",
   "license": "ISC",
   "type": "module",

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -31,7 +31,7 @@ export const Modal = ({
   if (!props.open) return <></>;
 
   return (
-    <FocusLock>
+    <FocusLock autoFocus={!!props.initialFocusRef}>
       <div
         onClick={props.onDismiss}
         className={classNames(props.className, c.backdrop)}


### PR DESCRIPTION
Fixes https://github.com/fabric-ds/issues/issues/118 

## Issue
The issue occured on Safari when the Modal with no `initialFocusRef` was opened on"Open Modal" button click (NOT on keypress). 
So when an “Open Modal” button is clicked, no content is visible on the page and an error message in the console writes:
`TypeError: target is not an Object. (evaluating '"focus" in target')`
![gif-displaying-safari-console-error-on-modal-open](https://user-images.githubusercontent.com/41303231/202484434-8c04c83b-fa0c-49c9-b55a-d36746412347.gif)


## Suggested fix
Set `autoFocus` prop of `FocusLock` component to `false` if `initialFocusRef` prop value is falsy.

![gif-displaying-modal-opening-on-safari-without-error](https://user-images.githubusercontent.com/41303231/202484606-6efed6d6-2e59-4e57-a739-9a6e48ff1489.gif)

## Note
This is rather a quick fix because it removes the default autofocus when the Modal is opened. Unless the `initialFocusRef` prop is available, the user will need to tab once in order to get focus on the first element within the Modal.

I haven't managed to figure out any other way to fix the issue on Safari but I'm happy to hear from others :)