### PR TITLE
fix(modal): cleanup scroll-doctor lock on unmount

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -21,6 +21,10 @@ export const Modal = ({
     teardown();
     if (!contentRef.current) return;
     props.open && setup(contentRef.current);
+
+    return () => {
+      teardown();
+    };
   }, [props.open, contentRef]);
 
   useEffect(() => {


### PR DESCRIPTION
This should ensure that the scroll lock gets removed when the modal closes