### PR TITLE
fix: update with main & add GHA for rebasing after a release

### DIFF
--- a/.github/workflows/update-alpha.yml
+++ b/.github/workflows/update-alpha.yml
@@ -1,0 +1,20 @@
+name: Update next
+on:
+  workflow_run:
+    workflows:
+      - Release
+    branches:
+      - main
+    types: completed
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Rebase next to main
+        run: |
+          git fetch --unshallow
+          git checkout next
+          git rebase origin/main
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.5.1](https://github.com/fabric-ds/react/compare/v1.5.0...v1.5.1) (2023-03-02)
+
+
+### Bug Fixes
+
+* **modal:** cleanup scroll-doctor lock on unmount ([74a5c89](https://github.com/fabric-ds/react/commit/74a5c896d4cf8c7b111526e68500f66b0a9de5f7))
+
 ## [1.5.1-next.1](https://github.com/fabric-ds/react/compare/v1.5.0...v1.5.1-next.1) (2023-03-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabric-ds/react",
-  "version": "1.5.1-next.1",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabric-ds/react",
-      "version": "1.5.1-next.1",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@chbphone55/classnames": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabric-ds/react",
-  "version": "1.5.1-next.1",
+  "version": "1.5.1",
   "repository": "git@github.com:fabric-ds/react.git",
   "license": "ISC",
   "type": "module",


### PR DESCRIPTION
Fixes git history to allow publishing of a previously merged [slider fix](https://github.com/fabric-ds/react/pull/187).

We've again stumbled upon a problem of `next` branch git history diverging from `main` after a cut release.
A github action for rebasing `next` on top of `main` after a completed Release job should fix this for us 🤞 