### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/packages/card/docs/Card.mdx
+++ b/packages/card/docs/Card.mdx
@@ -19,7 +19,7 @@ import { Card } from '@fabric-ds/react';
   <Card>
     <img
       className="h-128 w-full object-cover"
-      src="https://source.unsplash.com/random/400x400"
+      src="https://picsum.photos/seed/fabric-card-1/400/400"
       alt="Description"
     />
     <p className="absolute top-12 left-12 bg-aqua-200 text-aqua-900 p-4 rounded-4 text-12">
@@ -54,7 +54,7 @@ import { Card } from '@fabric-ds/react';
   <Card>
     <img
       className="h-128 w-full object-cover"
-      src="https://source.unsplash.com/random/402x402"
+      src="https://picsum.photos/seed/fabric-card-2/402/402"
       alt="Description"
     />
     <div className="p-16">
@@ -86,7 +86,7 @@ import { Card } from '@fabric-ds/react';
   <Card>
     <img
       className="h-128 w-full object-cover"
-      src="https://source.unsplash.com/random/404x404"
+      src="https://picsum.photos/seed/fabric-card-3/404/404"
       alt="Description"
     />
     <div className="p-16">


### PR DESCRIPTION
`packages/card/docs/Card.mdx` references the deprecated `source.unsplash.com/*` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and related endpoints like `/featured`, `/collection/<id>`) was deprecated by Unsplash in mid-2024. These URLs now return HTTP 503 instead of an image, so browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600 | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Fixes the 3 `<img>` URLs in the fabric-ds React Card component docs so each card variant in the docs renders a distinct image.

#### Replacement details

Schibsted's fabric-ds design system docs rely on per-card-variant images to demonstrate the component. All three dimension variants (400, 402, 404) and the surrounding attributes (className `h-128 w-full object-cover`, alt) are preserved.

#### Background

I'm tracking the deprecated `source.unsplash.com/*` endpoints across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
